### PR TITLE
keyboard navigation of columns/rows

### DIFF
--- a/src/components/Grid/components/Cell/index.tsx
+++ b/src/components/Grid/components/Cell/index.tsx
@@ -91,18 +91,28 @@ export const Cell: React.FC<Props> = memo(
             ? undefined
             : (e) => {
                 menu.onContextMenu(menuItems)(e)
-                hovered.update({
-                  row: rowId,
-                  column: columnId,
-                })
+                hovered.update(
+                  {
+                    row: rowId,
+                    column: columnId,
+                    key: false,
+                  },
+                  pinnedRow,
+                  pinnedColumn
+                )
               }
         }
         onMouseEnter={useCallback(
           () =>
-            hovered.update({
-              row: rowId,
-              column: columnId,
-            }),
+            hovered.update(
+              {
+                row: rowId,
+                column: columnId,
+                key: false,
+              },
+              pinnedRow,
+              pinnedColumn
+            ),
           [rowId, columnId, hovered]
         )}
         hovered={hovered.row === rowId}

--- a/src/components/Grid/components/Header/index.tsx
+++ b/src/components/Grid/components/Header/index.tsx
@@ -4,15 +4,13 @@ import { HeaderRow } from '../HeaderRow'
 import { Row } from '../Row'
 import { HeaderCell } from '../HeaderCell'
 import { Spacer } from '../Spacer'
-import { useConfig, useHovers, useMenu, useScroll } from '../../../../context'
+import { useConfig, useScroll } from '../../../../context'
 import { GridProps } from '../../../../types'
 
 export const Header: React.FC<GridProps> = memo(
   ({ columns, innerRef, pinned, scrollX, calculateColumnWidth }) => {
     const { headerCellRenderer, ...config } = useConfig()
     const { positions, update } = useScroll()
-    const { menuState } = useMenu()
-    const hovers = useHovers()
     const keyPrefix = pinned ? 'pinned' : 'main'
 
     const cellRenderer: GridCellRenderer = useCallback(
@@ -62,13 +60,7 @@ export const Header: React.FC<GridProps> = memo(
     )
 
     return (
-      <HeaderRow
-        rowHeight={config.rowHeight}
-        onMouseEnter={useCallback(
-          () => (menuState.visible ? null : hovers.update({ row: null, column: null })),
-          [menuState.visible]
-        )}
-      >
+      <HeaderRow rowHeight={config.rowHeight}>
         <Row>
           <AutoSizer disableHeight>
             {({ width }) => (

--- a/src/components/Grid/components/HeaderCell/index.tsx
+++ b/src/components/Grid/components/HeaderCell/index.tsx
@@ -19,9 +19,6 @@ const Wrapper = styled.div<WrapperProps>`
   &:first-child {
     border-left: none;
   }
-  &:hover {
-    background: ${({ theme }) => theme.backgroundHeaderHover};
-  }
   .resizing & {
     background: ${({ theme }) => theme.backgroundHeader};
   }

--- a/src/components/Grid/components/Main/index.tsx
+++ b/src/components/Grid/components/Main/index.tsx
@@ -3,7 +3,7 @@ import { AutoSizer, Grid, GridCellRenderer, OnScrollParams } from 'react-virtual
 import { Row } from '../Row'
 import { Cell } from '../Cell'
 import { Scrollbar } from '../Scrollbar'
-import { useConfig, useData, useScroll, useView } from '../../../../context'
+import { useConfig, useData, useScroll, useView, useHovers } from '../../../../context'
 import { GridProps } from '../../../../types'
 import utils from '../../../../utils'
 
@@ -14,6 +14,7 @@ export const Main: React.FC<GridProps> = memo(
     const { positions, update } = useScroll()
     const view = useView()
     const keyPrefix = pinned ? 'pinned' : 'main'
+    const { key: keyboardNavOccured, cell: highlightedCell } = useHovers()
 
     const cellRenderer: GridCellRenderer = useCallback(
       ({ style, columnIndex, rowIndex }) => {
@@ -88,6 +89,15 @@ export const Main: React.FC<GridProps> = memo(
       [innerRef, positions.main.default.left]
     )
 
+    let scrollToColumn: number | undefined
+
+    if (
+      keyboardNavOccured &&
+      ((!pinned && !highlightedCell.pinnedColumn) || (pinned && highlightedCell.pinnedColumn))
+    ) {
+      scrollToColumn = highlightedCell.column!
+    }
+
     return (
       <>
         <Row flexed>
@@ -105,6 +115,12 @@ export const Main: React.FC<GridProps> = memo(
                   rowHeight={config.rowHeight}
                   scrollLeft={scrollX}
                   scrollTop={positions.main.default.top}
+                  scrollToRow={
+                    !pinned && keyboardNavOccured && !highlightedCell.pinnedRow
+                      ? highlightedCell.row!
+                      : undefined
+                  }
+                  scrollToColumn={scrollToColumn}
                   tabIndex={-1}
                   width={width}
                 />

--- a/src/components/Grid/components/Pinned/index.tsx
+++ b/src/components/Grid/components/Pinned/index.tsx
@@ -4,7 +4,7 @@ import { PinnedRow } from '../PinnedRow'
 import { Row } from '../Row'
 import { Cell } from '../Cell'
 import { Scrollbar } from '../Scrollbar'
-import { useConfig, useData, useScroll, useView } from '../../../../context'
+import { useConfig, useData, useScroll, useView, useHovers } from '../../../../context'
 import { GridProps } from '../../../../types'
 import utils from '../../../../utils'
 
@@ -14,6 +14,7 @@ export const Pinned: React.FC<GridProps> = memo(
     const { cellRenderer: cellRendererProp, ...config } = useConfig()
     const data = useData()
     const { positions, update } = useScroll()
+    const { key: keyboardNavOccured, cell: highlightedCell } = useHovers()
     const keyPrefix = pinned ? 'pinned' : 'main'
 
     const cellRenderer: GridCellRenderer = useCallback(
@@ -97,6 +98,11 @@ export const Pinned: React.FC<GridProps> = memo(
                 rowHeight={config.rowHeight}
                 scrollLeft={scrollX}
                 scrollTop={positions.main.pinned.top}
+                scrollToRow={
+                  !pinned && keyboardNavOccured && highlightedCell.pinnedRow
+                    ? highlightedCell.row!
+                    : undefined
+                }
                 tabIndex={-1}
                 width={width}
               />

--- a/src/components/Selection/index.tsx
+++ b/src/components/Selection/index.tsx
@@ -103,6 +103,7 @@ export const Selection = memo(() => {
         >
           <Placer>
             <input
+              tabIndex={-1}
               type="checkbox"
               checked={selection.isItemSelected(id) || selection.isAllSelected}
               onChange={() => selection.toggleItemSelection(id)}
@@ -129,6 +130,7 @@ export const Selection = memo(() => {
         >
           <Placer>
             <input
+              tabIndex={-1}
               type="checkbox"
               checked={selection.isItemSelected(id) || selection.isAllSelected}
               onChange={() => selection.toggleItemSelection(id)}
@@ -144,6 +146,7 @@ export const Selection = memo(() => {
     <Wrapper>
       <SelectAll rowHeight={config.rowHeight}>
         <input
+          tabIndex={-1}
           type="checkbox"
           checked={selection.isAllSelected}
           onChange={() => selection.toggleSelectAll()}

--- a/src/components/Wrapper/index.ts
+++ b/src/components/Wrapper/index.ts
@@ -12,6 +12,7 @@ export const Wrapper = styled.div`
   font-size: ${({ theme }) => theme.fontSize}px;
   line-height: ${({ theme }) => theme.fontSize / 10};
   user-select: none;
+  outline: none;
 
   &.resizing {
     cursor: e-resize !important;
@@ -19,6 +20,10 @@ export const Wrapper = styled.div`
 
   &.reordering {
     cursor: grabbing;
+  }
+
+  &.kill-events {
+    pointer-events: none;
   }
 
   &:after {
@@ -32,5 +37,12 @@ export const Wrapper = styled.div`
     pointer-events: none;
     z-index: 1;
     border: ${({ theme }) => `${theme.borderWidth}px solid ${theme.borderColorHeader}`};
+  }
+
+  &.active {
+    box-shadow: 0 0 3px ${({ theme }) => theme.primaryColor};
+    &:after {
+      border-color: ${({ theme }) => theme.primaryColor};
+    }
   }
 `

--- a/src/context/hovers.ts
+++ b/src/context/hovers.ts
@@ -5,13 +5,27 @@ import { HoverState, ID } from '../types'
 interface HoverContextProps {
   row: ID | null
   column: ID | null
-  update: (_: HoverState) => void
+  key: boolean
+  cell: {
+    row: number | null
+    column: number | null
+    pinnedColumn: boolean
+    pinnedRow: boolean
+  }
+  update: (state: HoverState, pinnedRow?: boolean, pinnedColumn?: boolean) => void
 }
 
 const context = createContext<HoverContextProps>({
   row: null,
   column: null,
+  key: false,
   update: DEFAULT_ACTION,
+  cell: {
+    row: null,
+    column: null,
+    pinnedColumn: false,
+    pinnedRow: false,
+  },
 })
 
 export const { Provider: HoverProvider } = context

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useColumnReorder'
 export * from './useColumnResize'
 export * from './useContextMenu'
+export * from './useHovers'
 export * from './usePinnedColumns'
 export * from './usePinnedRows'
 export * from './useSelection'

--- a/src/hooks/useColumnReorder.ts
+++ b/src/hooks/useColumnReorder.ts
@@ -106,7 +106,7 @@ export const useColumnReorder = (
 
   return {
     initializeReorder,
-    columnOrder,
+    columnOrder: filteredOrder,
     reorderColumn,
     confirmReorder,
     reorderIndicator,

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState, MouseEvent } from 'react'
+import { useRef, useState, MouseEvent } from 'react'
 
-export const useContextMenu = () => {
+export const useContextMenu = (wrapperRef: any) => {
   const menuRef = useRef<HTMLDivElement>((null as unknown) as HTMLDivElement)
   const activeRef = useRef<EventTarget>((null as unknown) as EventTarget)
   const [children, setChildren] = useState(null)
@@ -20,6 +20,9 @@ export const useContextMenu = () => {
       y: e.clientY,
     })
     setChildren(children)
+    window.addEventListener('blur', closeMenu)
+    document.addEventListener('mousedown', closeMenu)
+    document.addEventListener('contextmenu', closeMenu)
   }
 
   const closeMenu = (e?: any) => {
@@ -36,24 +39,16 @@ export const useContextMenu = () => {
       visible: false,
     })
     setChildren(null)
+    wrapperRef.current.focus()
+    window.removeEventListener('blur', closeMenu)
+    document.removeEventListener('mousedown', closeMenu)
+    document.removeEventListener('contextmenu', closeMenu)
   }
 
   const triggerMenuAction = (action: any) => () => {
     action()
     closeMenu()
   }
-
-  useEffect(() => {
-    window.addEventListener('blur', closeMenu)
-    document.addEventListener('mousedown', closeMenu)
-    document.addEventListener('contextmenu', closeMenu)
-    return () => {
-      window.removeEventListener('blur', closeMenu)
-      document.removeEventListener('mousedown', closeMenu)
-      document.removeEventListener('contextmenu', closeMenu)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   return {
     triggerMenuAction,

--- a/src/hooks/useHovers.ts
+++ b/src/hooks/useHovers.ts
@@ -1,0 +1,120 @@
+import { useMemo, useState } from 'react'
+import { HoverState, RowData, ID } from '../types'
+
+interface State extends HoverState {
+  cell: {
+    row: number | null
+    column: number | null
+    pinnedColumn: boolean
+    pinnedRow: boolean
+  }
+}
+
+let timeout: any
+let scrolling = false
+
+export const useHovers = (
+  pinnedRows: ID[],
+  pinnedColumns: ID[],
+  columnOrder: ID[],
+  rowData: RowData[],
+  wrapperRef: any
+) => {
+  const rowOrder = useMemo(() => rowData.map((r) => r.id), [rowData, pinnedRows])
+  const columns = pinnedColumns.concat(columnOrder)
+  const rows = pinnedRows.concat(rowOrder)
+
+  const [hovered, setHovers] = useState<State>({
+    row: null,
+    column: null,
+    key: false,
+    cell: {
+      row: null,
+      column: null,
+      pinnedColumn: false,
+      pinnedRow: false,
+    },
+  })
+
+  const updateHovered = (state: HoverState) => {
+    const cell =
+      state.column && state.row
+        ? {
+            row: pinnedRows.includes(state.row)
+              ? pinnedRows.indexOf(state.row)
+              : rowOrder.indexOf(state.row),
+            column: pinnedColumns.includes(state.column)
+              ? pinnedColumns.indexOf(state.column)
+              : columnOrder.indexOf(state.column),
+            pinnedRow: pinnedRows.includes(state.row),
+            pinnedColumn: pinnedColumns.includes(state.column),
+          }
+        : { row: null, column: null, pinnedColumn: false, pinnedRow: false }
+    setHovers({
+      ...state,
+      cell,
+    })
+  }
+
+  const handleStep = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab') e.preventDefault()
+    if (e.key === 'Tab') return
+    clearTimeout(timeout)
+    if (!scrolling) {
+      scrolling = true
+      wrapperRef.current.classList.add('kill-events')
+      let newRow = hovered.row !== null ? hovered.row : rows[0]
+      let newColumn = hovered.column !== null ? hovered.column : columns[0]
+      let newRowIndex
+      let newColumnIndex
+      switch (e.key) {
+        case 'ArrowDown':
+          newRowIndex = rows.indexOf(hovered.row ?? rows[rows.length]) + 1
+          newRow = newRowIndex > rows.length - 1 ? rows[0] : rows[newRowIndex]
+          break
+        case 'ArrowUp':
+          newRowIndex = rows.indexOf(hovered.row ?? rows[0]) - 1
+          newRow = newRowIndex < 0 ? rows[rows.length - 1] : rows[newRowIndex]
+          break
+        case 'ArrowRight':
+          newColumnIndex = columns.indexOf(hovered.column ?? columns[columns.length]) + 1
+          newColumn = newColumnIndex > columns.length - 1 ? columns[0] : columns[newColumnIndex]
+          break
+        case 'ArrowLeft':
+          newColumnIndex = columns.indexOf(hovered.column ?? columns[0]) - 1
+          newColumn = newColumnIndex < 0 ? columns[columns.length - 1] : columns[newColumnIndex]
+          break
+      }
+
+      const cell = {
+        row: pinnedRows.includes(newRow) ? pinnedRows.indexOf(newRow) : rowOrder.indexOf(newRow),
+        column: pinnedColumns.includes(newColumn)
+          ? pinnedColumns.indexOf(newColumn)
+          : columnOrder.indexOf(newColumn),
+        pinnedRow: pinnedRows.includes(newRow),
+        pinnedColumn: pinnedColumns.includes(newColumn),
+      }
+
+      setHovers({
+        row: newRow,
+        column: newColumn,
+        key: true,
+        cell,
+      })
+
+      setTimeout(() => {
+        scrolling = false
+      }, 50)
+    }
+
+    timeout = setTimeout(() => {
+      wrapperRef.current.classList.remove('kill-events')
+    }, 500)
+  }
+
+  return {
+    hovered,
+    updateHovered,
+    handleStep,
+  }
+}

--- a/src/hooks/useTableData.ts
+++ b/src/hooks/useTableData.ts
@@ -27,13 +27,11 @@ export const useTableData = ({
     () => pinnedColumns.map((c) => utils.find(data.columns, c, 'id')),
     [data.columns, pinnedColumns]
   )
-  const columnData = useMemo(
-    () =>
-      utils
-        .filter(columnOrder, (c) => !pinnedColumns.includes(c))
-        .map((c) => utils.find(data.columns, c, 'id')),
-    [data.columns, columnOrder, pinnedColumns]
-  )
+  const columnData = useMemo(() => columnOrder.map((c) => utils.find(data.columns, c, 'id')), [
+    data.columns,
+    columnOrder,
+    pinnedColumns,
+  ])
 
   return {
     pinnedRows: pinnedRowData,

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export interface GridProps {
 export interface HoverState {
   row: ID | null
   column: ID | null
+  key: boolean
 }
 
 export interface Theme {

--- a/stories/BigDataTable.stories.tsx
+++ b/stories/BigDataTable.stories.tsx
@@ -54,8 +54,8 @@ const Template: Story<BigDataTableProps> = () => (
       rowHeight={30}
       defaultColumnWidth={150}
       defaultView={{
-        pinnedRows: [0, 1, 2],
-        pinnedColumns: [3, 4, 5],
+        pinnedRows: [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 50, 51, 52, 56, 57, 58, 59, 60],
+        pinnedColumns: [3, 4, 5, 8, 6, 20, 43, 25, 60, 45, 50, 51, 52, 53, 71, 72, 74, 75],
         columnOrder: data.columns.map((c) => c.id).sort(() => Math.random() - 0.5),
         columnSizes: {
           4: 300,


### PR DESCRIPTION
- Added ability to navigate columns/rows with arrow keys
- Added focus styling for table to indicate the table is keyboard navigable
- Refocus table after context menu closes
- Removed mouse events which cleared hover state when mousing outside of the table to preserve navigation position